### PR TITLE
Handle wrapping of network streams, and auto download nuget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Release/
 *.user
 *.suo
 BenchmarkDotNet.Artifacts/
+/nuget.exe

--- a/paket.cmd
+++ b/paket.cmd
@@ -1,5 +1,10 @@
 @echo off
 
+@where /q nuget
+@IF ERRORLEVEL 1 (
+	powershell -Command "Invoke-WebRequest https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile nuget.exe"
+)
+
 setlocal
 set target=%~dp0\.paket
 set paket=%target%\paket.exe


### PR DESCRIPTION
Great work on an awesome project, here.  Thanks.

Two things in this pull request
1. nuget.exe is not on the path by default always in Windows, so paket.cmd fails.  I added code that detects if this is true and auto downloads it so that it is really possible to clone and build.
2. The decoding stream fails if you wrap a network stream because it expects every call to Read() to read every byte it asks for, but network streams often return short reads.  I ran into this trying to decode a file as it was being downloaded from S3, but it failed every time unless I downloaded the whole file to a memory stream first, and then wrapped the memory stream.  So this change adds a test that simulates the shortest possible reads (which fails) and adds the fix for it.