### PR TITLE
Expand LZ4Pickler API to enable better perf & composability.

### DIFF
--- a/src/K4os.Compression.LZ4.Test/PicklingTests.cs
+++ b/src/K4os.Compression.LZ4.Test/PicklingTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using K4os.Compression.LZ4.Internal;
 using TestHelpers;
 using Xunit;
@@ -31,6 +32,35 @@ namespace K4os.Compression.LZ4.Test
 		}
 
 		[Theory]
+		[InlineData(0)]
+		[InlineData(10)]
+		[InlineData(32)]
+		[InlineData(1337)]
+		[InlineData(1337, LZ4Level.L09_HC)]
+		[InlineData(0x10000)]
+		[InlineData(0x172a5, LZ4Level.L00_FAST)]
+		[InlineData(0x172a5, LZ4Level.L09_HC)]
+		[InlineData(0x172a5, LZ4Level.L11_OPT)]
+		[InlineData(0x172a5, LZ4Level.L12_MAX)]
+		[InlineData(Mem.M4, LZ4Level.L12_MAX)]
+		public void PickleLoremWithBufferWriter(int length, LZ4Level level = LZ4Level.L00_FAST)
+		{
+			var original = new byte[length];
+			Lorem.Fill(original, 0, length);
+
+			var pickledWriter = new ArrayBufferWriter<byte>();
+			var unpickledWriter = new ArrayBufferWriter<byte>();
+
+			LZ4Pickler.Pickle(original, pickledWriter, level);
+			var pickled = pickledWriter.WrittenSpan;
+
+			LZ4Pickler.Unpickle(pickled, unpickledWriter);
+			var unpickled = unpickledWriter.WrittenSpan;
+
+			Tools.SameBytes(original, unpickled);
+		}
+
+		[Theory]
 		[InlineData(1, 15)]
 		[InlineData(2, 1024)]
 		[InlineData(3, 1337, LZ4Level.L09_HC)]
@@ -44,6 +74,30 @@ namespace K4os.Compression.LZ4.Test
 
 			var pickled = LZ4Pickler.Pickle(original, level);
 			var unpickled = LZ4Pickler.Unpickle(pickled);
+
+			Tools.SameBytes(original, unpickled);
+		}
+
+		[Theory]
+		[InlineData(1, 15)]
+		[InlineData(2, 1024)]
+		[InlineData(3, 1337, LZ4Level.L09_HC)]
+		[InlineData(3, 1337, LZ4Level.L12_MAX)]
+		[InlineData(4, Mem.K64, LZ4Level.L12_MAX)]
+		[InlineData(5, Mem.M4, LZ4Level.L12_MAX)]
+		public void PickleEntropyWithBufferWriter(int seed, int length, LZ4Level level = LZ4Level.L00_FAST)
+		{
+			var original = new byte[length];
+			new Random(seed).NextBytes(original);
+
+			var pickledWriter = new ArrayBufferWriter<byte>();
+			var unpickledWriter = new ArrayBufferWriter<byte>();
+
+			LZ4Pickler.Pickle(original, pickledWriter, level);
+			var pickled = pickledWriter.WrittenSpan;
+
+			LZ4Pickler.Unpickle(pickled, unpickledWriter);
+			var unpickled = unpickledWriter.WrittenSpan;
 
 			Tools.SameBytes(original, unpickled);
 		}

--- a/src/K4os.Compression.LZ4/LZ4Pickler.cs
+++ b/src/K4os.Compression.LZ4/LZ4Pickler.cs
@@ -1,389 +1,312 @@
 ﻿using System;
 using System.Buffers;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Runtime.InteropServices;
 using K4os.Compression.LZ4.Internal;
 
 namespace K4os.Compression.LZ4
 {
-	/// <summary>
-	/// Pickling support with LZ4 compression.
-	/// </summary>
-	public static class LZ4Pickler
+    /// <summary>
+    /// Pickling support with LZ4 compression.
+    /// </summary>
+    public static class LZ4Pickler
 	{
-		private const byte VersionMask = 0x07;
-		private const byte CurrentVersion = 0 & VersionMask; // 3 bits
-
 		/// <summary>Compresses input buffer into self-contained package.</summary>
 		/// <param name="source">Input buffer.</param>
 		/// <param name="level">Compression level.</param>
 		/// <returns>Output buffer.</returns>
 		public static byte[] Pickle(byte[] source, LZ4Level level = LZ4Level.L00_FAST) =>
-			Pickle(source, 0, source.Length, level);
+			Pickle(source.AsSpan(), level);
 
 		/// <summary>Compresses input buffer into self-contained package.</summary>
 		/// <param name="source">Input buffer.</param>
-		/// <param name="level">Compression level.</param>
-		/// <param name="writer">Where the compressed data is written.</param>
-		public static void Pickle(byte[] source, IBufferWriter<byte> writer, LZ4Level level = LZ4Level.L00_FAST) =>
-			Pickle(source, 0, source.Length, writer, level);
-
-		/// <summary>Compresses input buffer into self-contained package.</summary>
-		/// <param name="source">Input buffer.</param>
-		/// <param name="sourceOffset">Input buffer offset.</param>
-		/// <param name="sourceLength">Input buffer length.</param>
+		/// <param name="index">Input buffer offset.</param>
+		/// <param name="count">Input buffer length.</param>
 		/// <param name="level">Compression level.</param>
 		/// <returns>Output buffer.</returns>
-		public static unsafe byte[] Pickle(
-			byte[] source, int sourceOffset, int sourceLength,
-			LZ4Level level = LZ4Level.L00_FAST)
-		{
-			source.Validate(sourceOffset, sourceLength);
-			fixed (byte* sourceP = source)
-				return Pickle(sourceP + sourceOffset, sourceLength, level);
-		}
+		public static byte[] Pickle(byte[] source, int index, int count, LZ4Level level = LZ4Level.L00_FAST) =>
+			Pickle(source.AsSpan(index, count), level);
 
 		/// <summary>Compresses input buffer into self-contained package.</summary>
 		/// <param name="source">Input buffer.</param>
-		/// <param name="sourceOffset">Input buffer offset.</param>
-		/// <param name="sourceLength">Input buffer length.</param>
+		/// <param name="count">Length of input data.</param>
 		/// <param name="level">Compression level.</param>
-		/// <param name="writer">Where the compressed data is written</param>
-		public static unsafe void Pickle(
-			byte[] source, int sourceOffset, int sourceLength, IBufferWriter<byte> writer,
-			LZ4Level level = LZ4Level.L00_FAST)
-		{
-			source.Validate(sourceOffset, sourceLength);
-			fixed (byte* sourceP = source)
-				Pickle(sourceP + sourceOffset, sourceLength, writer, level);
-		}
+		/// <returns>Output buffer.</returns>
+		public static unsafe byte[] Pickle(byte* source, int count, LZ4Level level = LZ4Level.L00_FAST) =>
+			Pickle(new Span<byte>(source, count), level);
 
 		/// <summary>Compresses input buffer into self-contained package.</summary>
 		/// <param name="source">Input buffer.</param>
 		/// <param name="level">Compression level.</param>
 		/// <returns>Output buffer.</returns>
-		public static unsafe byte[] Pickle(
-			ReadOnlySpan<byte> source, LZ4Level level = LZ4Level.L00_FAST)
+		public static unsafe byte[] Pickle(ReadOnlySpan<byte> source, LZ4Level level = LZ4Level.L00_FAST)
 		{
 			var sourceLength = source.Length;
-			if (sourceLength <= 0)
-				return Mem.Empty;
+			if (sourceLength == 0)
+			{
+				return Array.Empty<byte>();
+			}
 
-			fixed (byte* sourceP = &MemoryMarshal.GetReference(source))
-				return Pickle(sourceP, sourceLength, level);
-		}
-
-		/// <summary>Compresses input buffer into self-contained package.</summary>
-		/// <param name="source">Input buffer.</param>
-		/// <param name="level">Compression level.</param>
-		/// <param name="writer">Where the compressed data is written.</param>
-		/// <returns>Output buffer.</returns>
-		public static unsafe void Pickle(
-			ReadOnlySpan<byte> source, IBufferWriter<byte> writer, LZ4Level level = LZ4Level.L00_FAST)
-		{
-			var sourceLength = source.Length;
-			if (sourceLength <= 0)
-				return;
-
-			fixed (byte* sourceP = &MemoryMarshal.GetReference(source))
-				Pickle(sourceP, sourceLength, writer, level);
-		}
-
-		/// <summary>Compresses input buffer into self-contained package.</summary>
-		/// <param name="source">Input buffer.</param>
-		/// <param name="sourceLength">Length of input data.</param>
-		/// <param name="level">Compression level.</param>
-		/// <returns>Output buffer.</returns>
-		public static unsafe byte[] Pickle(
-			byte* source, int sourceLength, LZ4Level level = LZ4Level.L00_FAST)
-		{
-			if (sourceLength <= 0)
-				return Mem.Empty;
-
-			var targetLength = sourceLength - 1;
-			var target = (byte*) Mem.Alloc(sourceLength);
+			var tmp = Mem.Alloc(sourceLength);
 			try
 			{
-				var encodedLength = LZ4Codec.Encode(
-					source, sourceLength, target, targetLength, level);
-
-				return encodedLength <= 0
-					? PickleV0(source, sourceLength, sourceLength)
-					: PickleV0(target, encodedLength, sourceLength);
-			}
-			finally
-			{
-				Mem.Free(target);
-			}
-		}
-
-		/// <summary>Compresses input buffer into self-contained package.</summary>
-		/// <param name="source">Input buffer.</param>
-		/// <param name="sourceLength">Length of input data.</param>
-		/// <param name="level">Compression level.</param>
-		/// <param name="writer">Where the compressed data is written.</param>
-		public static unsafe void Pickle(
-			byte* source, int sourceLength, IBufferWriter<byte> writer, LZ4Level level = LZ4Level.L00_FAST)
-		{
-			if (sourceLength <= 0)
-				return;
-
-			var targetLength = sourceLength - 1;
-			var target = (byte*)Mem.Alloc(sourceLength);
-			try
-			{
-				var encodedLength = LZ4Codec.Encode(
-					source, sourceLength, target, targetLength, level);
-
+				int encodedLength = LZ4Codec.Encode(source, new Span<byte>(tmp, sourceLength), level);
 				if (encodedLength <= 0)
-					PickleV0(source, sourceLength, sourceLength, writer);
+				{
+					var result = new byte[sourceLength + 1];
+					EmitUncompressedPreamble(result);
+					source.CopyTo(result.AsSpan(1));
+					return result;
+				}
 				else
-					PickleV0(target, encodedLength, sourceLength, writer);
+				{
+					int diffBytes = CalcDiffBytes(sourceLength - encodedLength);
+					var result = new byte[1 + diffBytes + encodedLength];
+					var dst = result.AsSpan();
+					var src = new Span<byte>(tmp, encodedLength);
+					EmitCompressedPreamble(dst, sourceLength - encodedLength, diffBytes);
+					src.CopyTo(dst[(1 + diffBytes)..]);
+
+					return result;
+				}
 			}
 			finally
 			{
-				Mem.Free(target);
+				Mem.Free(tmp);
 			}
+		}
+
+		/// <summary>Compresses input buffer into self-contained package.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <param name="writer">Where the compressed data is written.</param>
+		/// <param name="level">Compression level.</param>
+		/// <returns>Output buffer.</returns>
+		public static void Pickle(ReadOnlySpan<byte> source, IBufferWriter<byte> writer, LZ4Level level = LZ4Level.L00_FAST)
+		{
+			var sourceLength = source.Length;
+			if (sourceLength == 0)
+			{
+				return;
+			}
+
+			int diffBytes = CalcDiffBytes(sourceLength);
+			var dst = writer.GetSpan(1 + diffBytes + sourceLength);
+
+			int encodedLength = LZ4Codec.Encode(source, dst.Slice(1 + diffBytes, sourceLength), level);
+			if (encodedLength <= 0)
+			{
+				EmitUncompressedPreamble(dst);
+				source.CopyTo(dst[1..]);
+				writer.Advance(1 + sourceLength);
+			}
+			else
+			{
+				EmitCompressedPreamble(dst, sourceLength - encodedLength, diffBytes);
+				writer.Advance(1 + diffBytes + encodedLength);
+			}
+		}
+
+		private static int CalcDiffBytes(int sourceLength)
+		{
+			if (sourceLength > 0xffff)
+			{
+				return 4;
+			}
+			else if (sourceLength > 0xff)
+			{
+				return 2;
+			}
+
+			return 1;
 		}
 
 		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
 		/// <param name="source">Input buffer.</param>
 		/// <returns>Output buffer.</returns>
 		public static byte[] Unpickle(byte[] source) =>
-			Unpickle(source, 0, source.Length);
+			Unpickle(source.AsSpan());
 
 		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
 		/// <param name="source">Input buffer.</param>
-		/// <param name="writer">Where the decompressed data is written.</param>
-		public static void Unpickle(byte[] source, IBufferWriter<byte> writer) =>
-			Unpickle(source, 0, source.Length, writer);
-
-		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
-		/// <param name="source">Input buffer.</param>
-		/// <param name="sourceOffset">Input buffer offset.</param>
-		/// <param name="sourceLength">Input buffer length.</param>
+		/// <param name="index">Input buffer offset.</param>
+		/// <param name="count">Input buffer length.</param>
 		/// <returns>Output buffer.</returns>
-		public static unsafe byte[] Unpickle(
-			byte[] source, int sourceOffset, int sourceLength)
-		{
-			source.Validate(sourceOffset, sourceLength);
-
-			if (sourceLength <= 0)
-				return Mem.Empty;
-
-			fixed (byte* sourceP = source)
-				return Unpickle(sourceP + sourceOffset, sourceLength);
-		}
+		public static unsafe byte[] Unpickle(byte[] source, int index, int count) =>
+			Unpickle(source.AsSpan(index, count));
 
 		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
 		/// <param name="source">Input buffer.</param>
-		/// <param name="sourceOffset">Input buffer offset.</param>
-		/// <param name="sourceLength">Input buffer length.</param>
-		/// <param name="writer">Where the decompressed data is wrtten.</param>
-		public static unsafe void Unpickle(
-			byte[] source, int sourceOffset, int sourceLength, IBufferWriter<byte> writer)
-		{
-			source.Validate(sourceOffset, sourceLength);
-
-			if (sourceLength <= 0)
-				return;
-
-			fixed (byte* sourceP = source)
-				Unpickle(sourceP + sourceOffset, sourceLength, writer);
-		}
+		/// <param name="count">Input buffer length.</param>
+		/// <returns>Output buffer.</returns>
+		public static unsafe byte[] Unpickle(byte* source, int count) =>
+			Unpickle(new Span<byte>(source, count));
 
 		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
 		/// <param name="source">Input buffer.</param>
 		/// <returns>Output buffer.</returns>
-		public static unsafe byte[] Unpickle(ReadOnlySpan<byte> source)
+		public static byte[] Unpickle(ReadOnlySpan<byte> source)
 		{
-			var sourceLength = source.Length;
-			if (sourceLength <= 0)
-				return Mem.Empty;
-
-			fixed (byte* sourceP = &MemoryMarshal.GetReference(source))
-				return Unpickle(sourceP, source.Length);
-		}
-
-		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
-		/// <param name="source">Input buffer.</param>
-		/// <param name="writer">Where the decompressed data is written.</param>
-		public static unsafe void Unpickle(ReadOnlySpan<byte> source, IBufferWriter<byte> writer)
-		{
-			var sourceLength = source.Length;
-			if (sourceLength <= 0)
-				return;
-
-			fixed (byte* sourceP = &MemoryMarshal.GetReference(source))
-				Unpickle(sourceP, source.Length, writer);
-		}
-
-		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
-		/// <param name="source">Input buffer.</param>
-		/// <param name="sourceLength">Input buffer length.</param>
-		/// <returns>Output buffer.</returns>
-		public static unsafe byte[] Unpickle(byte* source, int sourceLength)
-		{
-			if (sourceLength <= 0)
-				return Mem.Empty;
-
-			var flags = *source;
-			var version = flags & VersionMask; // 3 bits
-
-			if (version == 0)
-				return UnpickleV0(flags, source + 1, sourceLength - 1);
-
-			throw new InvalidDataException($"Pickle version {version} is not supported");
-		}
-
-		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
-		/// <param name="source">Input buffer.</param>
-		/// <param name="sourceLength">Input buffer length.</param>
-		/// <param name="writer">Where the decompressed data is written.</param>
-		public static unsafe void Unpickle(byte* source, int sourceLength, IBufferWriter<byte> writer)
-		{
-			if (sourceLength <= 0)
-				return;
-
-			var flags = *source;
-			var version = flags & VersionMask; // 3 bits
-
-			if (version == 0)
+			var size = UnpickledSize(source);
+			if (size == 0)
 			{
-				UnpickleV0(flags, source + 1, sourceLength - 1, writer);
+				return Array.Empty<byte>();
+			}
+
+			var output = new byte[size];
+			UnpickleCore(source, output, size);
+			return output;
+		}
+
+		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <param name="writer">Where the decompressed data is written.</param>
+		public static void Unpickle(ReadOnlySpan<byte> source, IBufferWriter<byte> writer)
+		{
+			if (source.Length == 0)
+			{
 				return;
 			}
 
-			throw new InvalidDataException($"Pickle version {version} is not supported");
+			var size = UnpickledSize(source);
+			var output = writer.GetSpan(size);
+			UnpickleCore(source, output, size);
+			writer.Advance(size);
+		}
+
+		/// <summary>
+		/// Returns the uncompressed size of a chunk of compressed data.
+		/// </summary>
+		/// <param name="source">The data to inspect.</param>
+		/// <returns>The size in bytes of the data once unpickled.</returns>
+		public static int UnpickledSize(ReadOnlySpan<byte> source)
+		{
+			var sourceLength = source.Length;
+			if (sourceLength == 0)
+			{
+				return 0;
+			}
+
+			var (version, diffBytes) = DecodeHeader(source[0]);
+			if (version != 0)
+			{
+				throw new InvalidDataException($"Pickle format {version} is not supported");
+			}
+
+			if (sourceLength <= diffBytes)
+			{
+				throw CorruptedPickle("Source buffer is too small.");
+			}
+
+			return sourceLength - 1 - diffBytes + ExtractDiff(source, diffBytes);
+		}
+
+		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <param name="output">Where the decompressed data is written.</param>
+		/// <remarks>
+		/// You obtain the size of the output buffer by calling <see cref="UnpickledSize(ReadOnlySpan{byte})"/>.
+		/// </remarks>
+		public static void Unpickle(ReadOnlySpan<byte> source, Span<byte> output)
+		{
+			var sourceLength = source.Length;
+			if (sourceLength == 0)
+			{
+				return;
+			}
+
+			var (version, diffBytes) = DecodeHeader(source[0]);
+			if (version != 0)
+			{
+				throw new InvalidDataException($"Pickling format {version} is not supported");
+			}
+
+			if (sourceLength <= diffBytes)
+			{
+				throw CorruptedPickle("Source buffer is too small.");
+			}
+
+			UnpickleCore(source, output, sourceLength - 1 - diffBytes + ExtractDiff(source, diffBytes));
+		}
+
+		private static void UnpickleCore(ReadOnlySpan<byte> source, Span<byte> output, int expectedLength)
+		{
+			var (_, diffBytes) = DecodeHeader(source[0]);
+			if (source.Length == expectedLength)
+			{
+				source[(1 + diffBytes)..].CopyTo(output);
+				return;
+			}
+
+			var src = source[(1 + diffBytes)..];
+			var decodedLength = LZ4Codec.Decode(src, output);
+			if (decodedLength != expectedLength)
+			{
+				throw CorruptedPickle($"Expected to decode {expectedLength} bytes but {decodedLength} has been decoded");
+			}
+		}
+
+		private static int ExtractDiff(ReadOnlySpan<byte> source, int diffBytes)
+		{
+			return diffBytes switch
+			{
+				1 => source[1],
+				2 => source[1] + (source[2] << 8),
+				4 => source[1] + (source[2] << 8) + (source[3] << 16) + (source[4] << 24),
+				_ => 0
+			};
+		}
+
+		private static void EmitUncompressedPreamble(Span<byte> result)
+		{
+			result[0] = EncodeHeader(0, 0);
+		}
+
+		private static void EmitCompressedPreamble(Span<byte> result, int length, int diffBytes)
+		{
+			switch (diffBytes)
+			{
+				case 1:
+					result[0] = EncodeHeader(0, 1);
+					result[1] = (byte)length;
+					break;
+
+				case 2:
+					result[0] = EncodeHeader(0, 2);
+					result[1] = (byte)(length & 0xff);
+					result[2] = (byte)(length >> 8);
+					break;
+
+				case 4:
+					result[0] = EncodeHeader(0, 4);
+					result[1] = (byte)(length & 0xff);
+					result[2] = (byte)((length >> 8) & 0xff);
+					result[3] = (byte)((length >> 16) & 0xff);
+					result[4] = (byte)(length >> 24);
+					break;
+			}
+		}
+
+		private static byte EncodeHeader(int version, byte diffBytes)
+		{
+			if (diffBytes == 4)
+			{
+				diffBytes = 3;
+			}
+
+			return (byte)((version & 0x07) | ((diffBytes & 0x3) << 6));
+		}
+
+		private static (int version, byte lengthBtes) DecodeHeader(byte header)
+		{
+			var len = (header >> 6) & 0x3;
+			if (len == 3)
+			{
+				len++;
+			}
+
+			return (header & 0x7, (byte)len);
 		}
 
 		private static Exception CorruptedPickle(string message) =>
 			new InvalidDataException($"Pickle is corrupted: {message}");
-
-		[SuppressMessage("ReSharper", "IdentifierTypo")]
-		private static unsafe byte[] PickleV0(
-			byte* target, int targetLength, int sourceLength)
-		{
-			var diff = sourceLength - targetLength;
-			var llen = diff == 0 ? 0 : diff < 0x100 ? 1 : diff < 0x10000 ? 2 : 4;
-			var result = new byte[targetLength + 1 + llen];
-
-			fixed (byte* resultP = result)
-			{
-				var llenFlags = llen == 4 ? 3 : llen; // 2 bits
-				var flags = (byte) ((llenFlags << 6) | CurrentVersion);
-				Mem.Poke1(resultP + 0, flags);
-				if (llen == 1) Mem.Poke1(resultP + 1, (byte) diff);
-				else if (llen == 2) Mem.Poke2(resultP + 1, (ushort) diff);
-				else if (llen == 4) Mem.Poke4(resultP + 1, (uint) diff);
-				Mem.Move(resultP + llen + 1, target, targetLength);
-			}
-
-			return result;
-		}
-
-		[SuppressMessage("ReSharper", "IdentifierTypo")]
-		private static unsafe void PickleV0(
-			byte* target, int targetLength, int sourceLength, IBufferWriter<byte> writer)
-		{
-			var diff = sourceLength - targetLength;
-			var llen = diff == 0 ? 0 : diff < 0x100 ? 1 : diff < 0x10000 ? 2 : 4;
-			var result = writer.GetSpan(targetLength + 1 + llen);
-
-			fixed (byte* resultP = result)
-			{
-				var llenFlags = llen == 4 ? 3 : llen; // 2 bits
-				var flags = (byte)((llenFlags << 6) | CurrentVersion);
-				Mem.Poke1(resultP + 0, flags);
-				if (llen == 1) Mem.Poke1(resultP + 1, (byte)diff);
-				else if (llen == 2) Mem.Poke2(resultP + 1, (ushort)diff);
-				else if (llen == 4) Mem.Poke4(resultP + 1, (uint)diff);
-				Mem.Move(resultP + llen + 1, target, targetLength);
-			}
-			writer.Advance(targetLength + 1 + llen);
-		}
-
-		private static unsafe byte[] UnpickleV0(
-			byte flags, byte* source, int sourceLength)
-		{
-			// ReSharper disable once IdentifierTypo
-			var llen = (flags >> 6) & 0x03; // 2 bits
-			if (llen == 3) llen = 4;
-
-			if (sourceLength < llen)
-				throw CorruptedPickle("Source buffer is too small.");
-
-			var diff = (int) (
-				llen == 0 ? 0 :
-				llen == 1 ? Mem.Peek1(source) :
-				llen == 2 ? Mem.Peek2(source) :
-				llen == 4 ? Mem.Peek4(source) :
-				throw CorruptedPickle("Unexpected length descriptor.")
-			);
-			source += llen;
-			sourceLength -= llen;
-			var targetLength = sourceLength + diff;
-
-			var target = new byte[targetLength];
-			fixed (byte* targetP = target)
-			{
-				if (diff == 0)
-				{
-					Mem.Copy(targetP, source, targetLength);
-				}
-				else
-				{
-					var decodedLength = LZ4Codec.Decode(
-						source, sourceLength, targetP, targetLength);
-					if (decodedLength != targetLength)
-						throw CorruptedPickle(
-							$"Expected {targetLength} bytes but {decodedLength} has been decoded");
-				}
-			}
-
-			return target;
-		}
-
-		private static unsafe void UnpickleV0(
-			byte flags, byte* source, int sourceLength, IBufferWriter<byte> writer)
-		{
-			// ReSharper disable once IdentifierTypo
-			var llen = (flags >> 6) & 0x03; // 2 bits
-			if (llen == 3) llen = 4;
-
-			if (sourceLength < llen)
-				throw CorruptedPickle("Source buffer is too small.");
-
-			var diff = (int)(
-				llen == 0 ? 0 :
-				llen == 1 ? Mem.Peek1(source) :
-				llen == 2 ? Mem.Peek2(source) :
-				llen == 4 ? Mem.Peek4(source) :
-				throw CorruptedPickle("Unexpected length descriptor.")
-			);
-			source += llen;
-			sourceLength -= llen;
-			var targetLength = sourceLength + diff;
-
-			var target = writer.GetSpan(targetLength);
-			fixed (byte* targetP = target)
-			{
-				if (diff == 0)
-				{
-					Mem.Copy(targetP, source, targetLength);
-				}
-				else
-				{
-					var decodedLength = LZ4Codec.Decode(
-						source, sourceLength, targetP, targetLength);
-					if (decodedLength != targetLength)
-						throw CorruptedPickle(
-							$"Expected {targetLength} bytes but {decodedLength} has been decoded");
-				}
-			}
-
-			writer.Advance(targetLength);
-		}
 	}
 }

--- a/src/TestHelpers/Tools.cs
+++ b/src/TestHelpers/Tools.cs
@@ -70,7 +70,7 @@ namespace TestHelpers
 		public static Stream Slow(Stream stream, int threshold = 1) =>
 			new FakeNetworkStream(stream, threshold);
 
-		public static void SameBytes(byte[] source, byte[] target)
+		public static void SameBytes(ReadOnlySpan<byte> source, ReadOnlySpan<byte> target)
 		{
 			if (source.Length != target.Length)
 				throw new ArgumentException(


### PR DESCRIPTION
- Introduce UnpickledSize which returns the expected size of a pickled
item once unpickled.

- Introduce an Unpickle overload which takes a Span&lt;byte&gt; and one that
takes an IBufferWriter for output. Both of these enable the caller to
reuse buffers across multiple unpicklings, which increases perf and
reduces pressure on the GC.

- Introduce a Pickle overload which takes an IBufferWriter as output.
Using this overload enables the caller to reuse buffers, and eliminates
a full data copy by unpickling directly into the final destination
buffer.

- The code was rewritten to mostly be safe by leveraging Span&lt;T&gt;. There
is only a teeny bit of unsafe code left in the pickling path.
