### PR TITLE
Improve pickling API and perf.

### DIFF
--- a/src/K4os.Compression.LZ4.Test/K4os.Compression.LZ4.Test.csproj
+++ b/src/K4os.Compression.LZ4.Test/K4os.Compression.LZ4.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;net462</TargetFrameworks>
+    <TargetFrameworks>net452;net462;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>Debug;Release</Configurations>

--- a/src/K4os.Compression.LZ4.Test/PicklingTests.cs
+++ b/src/K4os.Compression.LZ4.Test/PicklingTests.cs
@@ -1,4 +1,7 @@
 using System;
+#if NETSTANDARD2_1
+using System.Buffers;
+#endif
 using K4os.Compression.LZ4.Internal;
 using TestHelpers;
 using Xunit;
@@ -30,6 +33,37 @@ namespace K4os.Compression.LZ4.Test
 			Tools.SameBytes(original, unpickled);
 		}
 
+#if NETSTANDARD2_1
+		[Theory]
+		[InlineData(0)]
+		[InlineData(10)]
+		[InlineData(32)]
+		[InlineData(1337)]
+		[InlineData(1337, LZ4Level.L09_HC)]
+		[InlineData(0x10000)]
+		[InlineData(0x172a5, LZ4Level.L00_FAST)]
+		[InlineData(0x172a5, LZ4Level.L09_HC)]
+		[InlineData(0x172a5, LZ4Level.L11_OPT)]
+		[InlineData(0x172a5, LZ4Level.L12_MAX)]
+		[InlineData(Mem.M4, LZ4Level.L12_MAX)]
+		public void PickleLoremWithBufferWriter(int length, LZ4Level level = LZ4Level.L00_FAST)
+		{
+			var original = new byte[length];
+			Lorem.Fill(original, 0, length);
+
+			var pickledWriter = new ArrayBufferWriter<byte>();
+			var unpickledWriter = new ArrayBufferWriter<byte>();
+
+			LZ4Pickler.Pickle(original, pickledWriter, level);
+			var pickled = pickledWriter.WrittenSpan;
+
+			LZ4Pickler.Unpickle(pickled, unpickledWriter);
+			var unpickled = unpickledWriter.WrittenSpan;
+
+			Tools.SameBytes(original, unpickled);
+		}
+#endif
+
 		[Theory]
 		[InlineData(1, 15)]
 		[InlineData(2, 1024)]
@@ -47,6 +81,32 @@ namespace K4os.Compression.LZ4.Test
 
 			Tools.SameBytes(original, unpickled);
 		}
+
+#if NETSTANDARD2_1
+		[Theory]
+		[InlineData(1, 15)]
+		[InlineData(2, 1024)]
+		[InlineData(3, 1337, LZ4Level.L09_HC)]
+		[InlineData(3, 1337, LZ4Level.L12_MAX)]
+		[InlineData(4, Mem.K64, LZ4Level.L12_MAX)]
+		[InlineData(5, Mem.M4, LZ4Level.L12_MAX)]
+		public void PickleEntropyWithBufferWriter(int seed, int length, LZ4Level level = LZ4Level.L00_FAST)
+		{
+			var original = new byte[length];
+			new Random(seed).NextBytes(original);
+
+			var pickledWriter = new ArrayBufferWriter<byte>();
+			var unpickledWriter = new ArrayBufferWriter<byte>();
+
+			LZ4Pickler.Pickle(original, pickledWriter, level);
+			var pickled = pickledWriter.WrittenSpan;
+
+			LZ4Pickler.Unpickle(pickled, unpickledWriter);
+			var unpickled = unpickledWriter.WrittenSpan;
+
+			Tools.SameBytes(original, unpickled);
+		}
+#endif
 
 		[Theory]
 		[InlineData(0, 0)]

--- a/src/K4os.Compression.LZ4/K4os.Compression.LZ4.csproj
+++ b/src/K4os.Compression.LZ4/K4os.Compression.LZ4.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net45;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;netstandard2.1;net45;net46</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <PackageTags>compression lz4</PackageTags>

--- a/src/K4os.Compression.LZ4/LZ4Pickler.cs
+++ b/src/K4os.Compression.LZ4/LZ4Pickler.cs
@@ -1,7 +1,8 @@
-using System;
-using System.Diagnostics.CodeAnalysis;
+﻿using System;
+#if NETSTANDARD2_1
+using System.Buffers;
+#endif
 using System.IO;
-using System.Runtime.InteropServices;
 using K4os.Compression.LZ4.Internal;
 
 namespace K4os.Compression.LZ4
@@ -11,6 +12,306 @@ namespace K4os.Compression.LZ4
 	/// </summary>
 	public static class LZ4Pickler
 	{
+
+#if NETSTANDARD2_1
+		/// <summary>Compresses input buffer into self-contained package.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <param name="level">Compression level.</param>
+		/// <returns>Output buffer.</returns>
+		public static byte[] Pickle(byte[] source, LZ4Level level = LZ4Level.L00_FAST) =>
+			Pickle(source.AsSpan(), level);
+
+		/// <summary>Compresses input buffer into self-contained package.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <param name="index">Input buffer offset.</param>
+		/// <param name="count">Input buffer length.</param>
+		/// <param name="level">Compression level.</param>
+		/// <returns>Output buffer.</returns>
+		public static byte[] Pickle(byte[] source, int index, int count, LZ4Level level = LZ4Level.L00_FAST) =>
+			Pickle(source.AsSpan(index, count), level);
+
+		/// <summary>Compresses input buffer into self-contained package.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <param name="count">Length of input data.</param>
+		/// <param name="level">Compression level.</param>
+		/// <returns>Output buffer.</returns>
+		public static unsafe byte[] Pickle(byte* source, int count, LZ4Level level = LZ4Level.L00_FAST) =>
+			Pickle(new Span<byte>(source, count), level);
+
+		/// <summary>Compresses input buffer into self-contained package.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <param name="level">Compression level.</param>
+		/// <returns>Output buffer.</returns>
+		public static unsafe byte[] Pickle(ReadOnlySpan<byte> source, LZ4Level level = LZ4Level.L00_FAST)
+		{
+			var sourceLength = source.Length;
+			if (sourceLength == 0)
+			{
+				return Array.Empty<byte>();
+			}
+
+			var tmp = Mem.Alloc(sourceLength);
+			try
+			{
+				int encodedLength = LZ4Codec.Encode(source, new Span<byte>(tmp, sourceLength), level);
+				if (encodedLength <= 0)
+				{
+					var result = new byte[sourceLength + 1];
+					EmitUncompressedPreamble(result);
+					source.CopyTo(result.AsSpan(1));
+					return result;
+				}
+				else
+				{
+					int diffBytes = CalcDiffBytes(sourceLength - encodedLength);
+					var result = new byte[1 + diffBytes + encodedLength];
+					var dst = result.AsSpan();
+					var src = new Span<byte>(tmp, encodedLength);
+					EmitCompressedPreamble(dst, sourceLength - encodedLength, diffBytes);
+					src.CopyTo(dst[(1 + diffBytes)..]);
+
+					return result;
+				}
+			}
+			finally
+			{
+				Mem.Free(tmp);
+			}
+		}
+
+		/// <summary>Compresses input buffer into self-contained package.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <param name="writer">Where the compressed data is written.</param>
+		/// <param name="level">Compression level.</param>
+		/// <returns>Output buffer.</returns>
+		public static void Pickle(ReadOnlySpan<byte> source, IBufferWriter<byte> writer, LZ4Level level = LZ4Level.L00_FAST)
+		{
+			var sourceLength = source.Length;
+			if (sourceLength == 0)
+			{
+				return;
+			}
+
+			int diffBytes = CalcDiffBytes(sourceLength);
+			var dst = writer.GetSpan(1 + diffBytes + sourceLength);
+
+			int encodedLength = LZ4Codec.Encode(source, dst.Slice(1 + diffBytes, sourceLength), level);
+			if (encodedLength <= 0)
+			{
+				EmitUncompressedPreamble(dst);
+				source.CopyTo(dst[1..]);
+				writer.Advance(1 + sourceLength);
+			}
+			else
+			{
+				EmitCompressedPreamble(dst, sourceLength - encodedLength, diffBytes);
+				writer.Advance(1 + diffBytes + encodedLength);
+			}
+		}
+
+		private static int CalcDiffBytes(int sourceLength)
+		{
+			if (sourceLength > 0xffff)
+			{
+				return 4;
+			}
+			else if (sourceLength > 0xff)
+			{
+				return 2;
+			}
+
+			return 1;
+		}
+
+		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <returns>Output buffer.</returns>
+		public static byte[] Unpickle(byte[] source) =>
+			Unpickle(source.AsSpan());
+
+		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <param name="index">Input buffer offset.</param>
+		/// <param name="count">Input buffer length.</param>
+		/// <returns>Output buffer.</returns>
+		public static unsafe byte[] Unpickle(byte[] source, int index, int count) =>
+			Unpickle(source.AsSpan(index, count));
+
+		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <param name="count">Input buffer length.</param>
+		/// <returns>Output buffer.</returns>
+		public static unsafe byte[] Unpickle(byte* source, int count) =>
+			Unpickle(new Span<byte>(source, count));
+
+		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <returns>Output buffer.</returns>
+		public static byte[] Unpickle(ReadOnlySpan<byte> source)
+		{
+			var size = UnpickledSize(source);
+			if (size == 0)
+			{
+				return Array.Empty<byte>();
+			}
+
+			var output = new byte[size];
+			UnpickleCore(source, output, size);
+			return output;
+		}
+
+		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <param name="writer">Where the decompressed data is written.</param>
+		public static void Unpickle(ReadOnlySpan<byte> source, IBufferWriter<byte> writer)
+		{
+			if (source.Length == 0)
+			{
+				return;
+			}
+
+			var size = UnpickledSize(source);
+			var output = writer.GetSpan(size);
+			UnpickleCore(source, output, size);
+			writer.Advance(size);
+		}
+
+		/// <summary>
+		/// Returns the uncompressed size of a chunk of compressed data.
+		/// </summary>
+		/// <param name="source">The data to inspect.</param>
+		/// <returns>The size in bytes of the data once unpickled.</returns>
+		public static int UnpickledSize(ReadOnlySpan<byte> source)
+		{
+			var sourceLength = source.Length;
+			if (sourceLength == 0)
+			{
+				return 0;
+			}
+
+			var (version, diffBytes) = DecodeHeader(source[0]);
+			if (version != 0)
+			{
+				throw new InvalidDataException($"Pickle format {version} is not supported");
+			}
+
+			if (sourceLength <= diffBytes)
+			{
+				throw CorruptedPickle("Source buffer is too small.");
+			}
+
+			return sourceLength - 1 - diffBytes + ExtractDiff(source, diffBytes);
+		}
+
+		/// <summary>Decompresses previously pickled buffer (see: <see cref="LZ4Pickler"/>.</summary>
+		/// <param name="source">Input buffer.</param>
+		/// <param name="output">Where the decompressed data is written.</param>
+		/// <remarks>
+		/// You obtain the size of the output buffer by calling <see cref="UnpickledSize(ReadOnlySpan{byte})"/>.
+		/// </remarks>
+		public static void Unpickle(ReadOnlySpan<byte> source, Span<byte> output)
+		{
+			var sourceLength = source.Length;
+			if (sourceLength == 0)
+			{
+				return;
+			}
+
+			var (version, diffBytes) = DecodeHeader(source[0]);
+			if (version != 0)
+			{
+				throw new InvalidDataException($"Pickling format {version} is not supported");
+			}
+
+			if (sourceLength <= diffBytes)
+			{
+				throw CorruptedPickle("Source buffer is too small.");
+			}
+
+			UnpickleCore(source, output, sourceLength - 1 - diffBytes + ExtractDiff(source, diffBytes));
+		}
+
+		private static void UnpickleCore(ReadOnlySpan<byte> source, Span<byte> output, int expectedLength)
+		{
+			var (_, diffBytes) = DecodeHeader(source[0]);
+			if (source.Length == expectedLength)
+			{
+				source[(1 + diffBytes)..].CopyTo(output);
+				return;
+			}
+
+			var src = source[(1 + diffBytes)..];
+			var decodedLength = LZ4Codec.Decode(src, output);
+			if (decodedLength != expectedLength)
+			{
+				throw CorruptedPickle($"Expected to decode {expectedLength} bytes but {decodedLength} has been decoded");
+			}
+		}
+
+		private static int ExtractDiff(ReadOnlySpan<byte> source, int diffBytes)
+		{
+			return diffBytes switch
+			{
+				1 => source[1],
+				2 => source[1] + (source[2] << 8),
+				4 => source[1] + (source[2] << 8) + (source[3] << 16) + (source[4] << 24),
+				_ => 0
+			};
+		}
+
+		private static void EmitUncompressedPreamble(Span<byte> result)
+		{
+			result[0] = EncodeHeader(0, 0);
+		}
+
+		private static void EmitCompressedPreamble(Span<byte> result, int length, int diffBytes)
+		{
+			switch (diffBytes)
+			{
+				case 1:
+					result[0] = EncodeHeader(0, 1);
+					result[1] = (byte)length;
+					break;
+
+				case 2:
+					result[0] = EncodeHeader(0, 2);
+					result[1] = (byte)(length & 0xff);
+					result[2] = (byte)(length >> 8);
+					break;
+
+				case 4:
+					result[0] = EncodeHeader(0, 4);
+					result[1] = (byte)(length & 0xff);
+					result[2] = (byte)((length >> 8) & 0xff);
+					result[3] = (byte)((length >> 16) & 0xff);
+					result[4] = (byte)(length >> 24);
+					break;
+			}
+		}
+
+		private static byte EncodeHeader(int version, byte diffBytes)
+		{
+			if (diffBytes == 4)
+			{
+				diffBytes = 3;
+			}
+
+			return (byte)((version & 0x07) | ((diffBytes & 0x3) << 6));
+		}
+
+		private static (int version, byte lengthBtes) DecodeHeader(byte header)
+		{
+			var len = (header >> 6) & 0x3;
+			if (len == 3)
+			{
+				len++;
+			}
+
+			return (header & 0x7, (byte)len);
+		}
+
+#else  // version for legacy frameworks
+
 		private const byte VersionMask = 0x07;
 		private const byte CurrentVersion = 0 & VersionMask; // 3 bits
 
@@ -133,9 +434,6 @@ namespace K4os.Compression.LZ4
 			throw new InvalidDataException($"Pickle version {version} is not supported");
 		}
 
-		private static Exception CorruptedPickle(string message) =>
-			new InvalidDataException($"Pickle is corrupted: {message}");
-
 		[SuppressMessage("ReSharper", "IdentifierTypo")]
 		private static unsafe byte[] PickleV0(
 			byte* target, int targetLength, int sourceLength)
@@ -198,5 +496,9 @@ namespace K4os.Compression.LZ4
 
 			return target;
 		}
+#endif
+
+		private static Exception CorruptedPickle(string message) =>
+			new InvalidDataException($"Pickle is corrupted: {message}");
 	}
 }

--- a/src/TestHelpers/Tools.cs
+++ b/src/TestHelpers/Tools.cs
@@ -70,7 +70,7 @@ namespace TestHelpers
 		public static Stream Slow(Stream stream, int threshold = 1) =>
 			new FakeNetworkStream(stream, threshold);
 
-		public static void SameBytes(byte[] source, byte[] target)
+		public static void SameBytes(ReadOnlySpan<byte> source, ReadOnlySpan<byte> target)
 		{
 			if (source.Length != target.Length)
 				throw new ArgumentException(


### PR DESCRIPTION
This is a redo of my previous PR. I remain unable to build the full 
solution locally due to some dependencies that won't resolve. The
problem with my previous PR was the fact it was depending on features
not available for all the framework versions being targeted by this code.

I've made the new code conditional on .NET Standard 2.1 and expanded the
target frameworks for the library to include netstandard2.1. When building for
this version and beyond, the new APIs are available and the perf benefits 
kick in. When building against older frameworks, the previous code is used as
is.

I've built and tested this by modifying the build logic to address the
dependency problem I was having. Hopefully it'll work correctly using
your original build logic.

- Introduce UnpickledSize which returns the expected size of a pickled
item once unpickled.

- Introduce an Unpickle overload which takes a Span<byte> and one that
takes an IBufferWriter for output. Both of these enable the caller to
reuse buffers across multiple unpicklings, which increases perf and
reduces pressure on the GC.

- Introduce a Pickle overload which takes an IBufferWriter as output.
Using this overload enables the caller to reuse buffers, and eliminates
a full data copy by unpickling directly into the final destination
buffer.

- The code was rewritten to mostly be safe by leveraging Span<T>. There
is only a teeny bit of unsafe code left in the pickling path.