### PR TITLE
Slight bug fix

### DIFF
--- a/src/K4os.Compression.LZ4/LZ4Pickler.cs
+++ b/src/K4os.Compression.LZ4/LZ4Pickler.cs
@@ -234,7 +234,7 @@ namespace K4os.Compression.LZ4
 		private static void UnpickleCore(ReadOnlySpan<byte> source, Span<byte> output, int expectedLength)
 		{
 			var (_, diffBytes) = DecodeHeader(source[0]);
-			if (source.Length == expectedLength)
+			if (source.Length == expectedLength + 1)
 			{
 				source[(1 + diffBytes)..].CopyTo(output);
 				return;


### PR DESCRIPTION
I'm not sure how this slipped through, but it failed when trying to unpickle a data block that didn't get compressed.