### PR TITLE
Bug fix and improvements

### DIFF
--- a/src/K4os.Compression.LZ4.Test/PicklingTests.cs
+++ b/src/K4os.Compression.LZ4.Test/PicklingTests.cs
@@ -1,12 +1,14 @@
 using System;
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1 || NET5_0
 using System.Buffers;
 #endif
+using System.IO;
+using System.Linq;
+using K4os.Compression.LZ4;
 using K4os.Compression.LZ4.Internal;
-using TestHelpers;
 using Xunit;
 
-namespace K4os.Compression.LZ4.Test
+namespace Microsoft.R9.Extensions.Compression.Test
 {
 	public class PicklingTests
 	{
@@ -14,6 +16,7 @@ namespace K4os.Compression.LZ4.Test
 		[InlineData(0)]
 		[InlineData(10)]
 		[InlineData(32)]
+		[InlineData(200)]
 		[InlineData(1337)]
 		[InlineData(1337, LZ4Level.L09_HC)]
 		[InlineData(0x10000)]
@@ -22,22 +25,43 @@ namespace K4os.Compression.LZ4.Test
 		[InlineData(0x172a5, LZ4Level.L11_OPT)]
 		[InlineData(0x172a5, LZ4Level.L12_MAX)]
 		[InlineData(Mem.M4, LZ4Level.L12_MAX)]
-		public void PickleLorem(int length, LZ4Level level = LZ4Level.L00_FAST)
+		public unsafe void PickleLorem(int length, LZ4Level level = LZ4Level.L00_FAST)
 		{
 			var original = new byte[length];
 			Lorem.Fill(original, 0, length);
 
 			var pickled = LZ4Pickler.Pickle(original, level);
 			var unpickled = LZ4Pickler.Unpickle(pickled);
+			Assert.Equal(original, unpickled);
 
-			Tools.SameBytes(original, unpickled);
+			fixed (byte* p = original)
+			{
+				pickled = LZ4Pickler.Pickle(p, original.Length, level);
+			}
+
+			fixed (byte* p = pickled)
+			{
+				unpickled = LZ4Pickler.Unpickle(p, pickled.Length);
+			}
+
+			Assert.Equal(original, unpickled);
+
+			var copy = new byte[pickled.Length + 37];
+			Array.Copy(pickled, 0, copy, 37, pickled.Length);
+			unpickled = LZ4Pickler.Unpickle(copy, 37, pickled.Length);
+			Assert.Equal(original, unpickled);
+
+			unpickled.AsSpan().Fill(0);
+			LZ4Pickler.Unpickle(pickled.AsSpan(), unpickled.AsSpan());
+			Assert.Equal(original, unpickled);
 		}
 
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1 || NET5_0
 		[Theory]
 		[InlineData(0)]
 		[InlineData(10)]
 		[InlineData(32)]
+		[InlineData(200)]
 		[InlineData(1337)]
 		[InlineData(1337, LZ4Level.L09_HC)]
 		[InlineData(0x10000)]
@@ -54,13 +78,15 @@ namespace K4os.Compression.LZ4.Test
 			var pickledWriter = new ArrayBufferWriter<byte>();
 			var unpickledWriter = new ArrayBufferWriter<byte>();
 
+			Assert.Throws<ArgumentNullException>(() => LZ4Pickler.Pickle(original, null!, level));
 			LZ4Pickler.Pickle(original, pickledWriter, level);
 			var pickled = pickledWriter.WrittenSpan;
 
+			Assert.Throws<ArgumentNullException>(() => LZ4Pickler.Unpickle(pickledWriter.WrittenSpan, (IBufferWriter<byte>)null!));
 			LZ4Pickler.Unpickle(pickled, unpickledWriter);
 			var unpickled = unpickledWriter.WrittenSpan;
 
-			Tools.SameBytes(original, unpickled);
+			Assert.Equal(original.ToArray(), unpickled.ToArray());
 		}
 #endif
 
@@ -79,10 +105,10 @@ namespace K4os.Compression.LZ4.Test
 			var pickled = LZ4Pickler.Pickle(original, level);
 			var unpickled = LZ4Pickler.Unpickle(pickled);
 
-			Tools.SameBytes(original, unpickled);
+			Assert.Equal(original, unpickled);
 		}
 
-#if NETSTANDARD2_1
+#if NETSTANDARD2_1 || NET5_0
 		[Theory]
 		[InlineData(1, 15)]
 		[InlineData(2, 1024)]
@@ -104,7 +130,32 @@ namespace K4os.Compression.LZ4.Test
 			LZ4Pickler.Unpickle(pickled, unpickledWriter);
 			var unpickled = unpickledWriter.WrittenSpan;
 
-			Tools.SameBytes(original, unpickled);
+			Assert.Equal(original, unpickled.ToArray());
+		}
+
+		[Fact]
+		public void Corruption()
+		{
+			var source = new byte[1234];
+			Lorem.Fill(source, 0, source.Length);
+
+			var array = LZ4Pickler.Pickle(source);
+			var copy = array.AsSpan().ToArray();
+			var output = source.AsSpan().ToArray();
+
+			// pass a buffer that's too short
+			Assert.Throws<InvalidDataException>(() => LZ4Pickler.Unpickle(array.AsSpan().Slice(0, 2), output));
+			Assert.Throws<InvalidDataException>(() => LZ4Pickler.UnpickledSize(array.AsSpan().Slice(0, 2)));
+
+			// corrupt the version
+			array[0] = 0xff;
+			Assert.Throws<InvalidDataException>(() => LZ4Pickler.Unpickle(array, output));
+			Assert.Throws<InvalidDataException>(() => _ = LZ4Pickler.UnpickledSize(array));
+
+			// corrupt the size
+			array[0] = copy[0];
+			array[1] = 0xff;
+			Assert.Throws<InvalidDataException>(() => LZ4Pickler.Unpickle(array, output));
 		}
 #endif
 


### PR DESCRIPTION
- Fix issue with unpickling uncompressed block, it wasn't work correctly.

- Made the new code compile with .NET Standard 2.0 (it was previously
only for .NET Standard 2.1). This makes the code usable in many more
environments.

- Increased code coverage for the pickling code to 100%.

Again, I'm unable to build the bits from this repo directly myself
due to its use of the Paket stuff. But I've been building and using
these bits and the associated tests in our product builds internally.
So if you can get the build magic worked out, the code itself should
work well.