### PR TITLE
Added netstandard2.1

### DIFF
--- a/src/K4os.Compression.LZ4/K4os.Compression.LZ4.csproj
+++ b/src/K4os.Compression.LZ4/K4os.Compression.LZ4.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net45;net46;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;netstandard2.1;net45;net46;net5.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
     <PackageTags>compression lz4</PackageTags>


### PR DESCRIPTION
I couldn't get `netstandard2.0` version to work with Unity latest beta due to `System.Memory` conflicts.
It seems `netstandard2.1` helps since `System.Memory` isn't referenced anymore (types were moved to `netstandard` library).