### PR TITLE
Replace K4os.Hash.xxHash with System.IO.Hashing

### DIFF
--- a/src/K4os.Compression.LZ4.Roundtrip/Program.cs
+++ b/src/K4os.Compression.LZ4.Roundtrip/Program.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Hashing;
 using K4os.Compression.LZ4.Internal;
 using K4os.Compression.LZ4.Streams;
-using K4os.Hash.xxHash;
 
 namespace K4os.Compression.LZ4.Roundtrip
 {
@@ -87,17 +87,17 @@ namespace K4os.Compression.LZ4.Roundtrip
 
 		private static uint Checksum(Stream file)
 		{
-			var hash = new XXH32();
+			var hash = new XxHash32();
 			var buffer = new byte[0x10000];
 			while (true)
 			{
 				var read = file.Read(buffer, 0, buffer.Length);
 				if (read == 0) break;
 
-				hash.Update(buffer, 0, read);
+				hash.Append(buffer.AsSpan(0, read));
 			}
 
-			return hash.Digest();
+			return hash.GetCurrentHashAsUInt32();
 		}
 	}
 }

--- a/src/K4os.Compression.LZ4.Streams/Internal/Stash.cs
+++ b/src/K4os.Compression.LZ4.Streams/Internal/Stash.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Diagnostics;
+using System.IO.Hashing;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using K4os.Compression.LZ4.Internal;
-using K4os.Hash.xxHash;
 
 namespace K4os.Compression.LZ4.Streams.Internal;
 
@@ -147,6 +147,5 @@ internal struct Stash
 	
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public uint Digest(int offset = 0) =>
-		XXH32.DigestOf(AsSpan(offset));
-
+		XxHash32.HashToUInt32(AsSpan(offset));
 }

--- a/src/K4os.Compression.LZ4.Streams/K4os.Compression.LZ4.Streams.csproj
+++ b/src/K4os.Compression.LZ4.Streams/K4os.Compression.LZ4.Streams.csproj
@@ -23,7 +23,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <PackageReference Include="K4os.Hash.xxHash" Version="1.0.8" />
+    <PackageReference Include="System.IO.Hashing" Version="8.0.0-preview.1.23110.8" />
   </ItemGroup>
   <Import Project="..\..\Common.targets" />
   <Import Project="..\..\Signing.targets" />


### PR DESCRIPTION
The XxHash32 is implemented in System.IO.Hashing now. Switching the usages over to this package.

The System.IO.Hashing 8.0-preview1 package has the HashToUInt32 and GetCurrentHashAsUInt32 APIs. Using it for now, until 8.0 is released. If we want to use a stable package, I can use the 7.0 package, but will need a few wrapper methods to implement this functionality.

@MiloszKrajewski - if we take this approach, would it make sense to continue having 2 separate NuGet packages for LZ4? Or could we combine them into a single NuGet package?