### PR TITLE
Added Partial Decoding Support

### DIFF
--- a/src/K4os.Compression.LZ4.Test/PartialDecompressionTests.cs
+++ b/src/K4os.Compression.LZ4.Test/PartialDecompressionTests.cs
@@ -36,7 +36,7 @@ public class PartialDecompressionTests
         Check(encoded, encodedLength, encoded.Length - encodedLength, 0xCD);
 
         // Partially decode the file.
-        var decodedLength = LZ4Codec.DecodePartial(
+        var decodedLength = LZ4Codec.PartialDecode(
             encoded.AsSpan(0, encodedLength),
             decoded.AsSpan(0, numToDecompress));
 

--- a/src/K4os.Compression.LZ4.Test/PartialDecompressionTests.cs
+++ b/src/K4os.Compression.LZ4.Test/PartialDecompressionTests.cs
@@ -1,0 +1,65 @@
+using System;
+using TestHelpers;
+using Xunit;
+
+namespace K4os.Compression.LZ4.Test;
+
+public class PartialDecompressionTests
+{
+    [Theory]
+    // Full Decompress
+    [InlineData(127, 127)] // prime
+    [InlineData(128, 128)]
+    [InlineData(256, 256)]
+    // Prime Sizes
+    [InlineData(512, 17)] // One prime, one power of two
+    [InlineData(511, 13)] // Both prime
+    [InlineData(511, 31)] // Both prime
+    public void CanDecodePartialCompressedBufferWithSpan(int sourceLength, int numToDecompress)
+    {
+        var targetLength = LZ4Codec.MaximumOutputSize(sourceLength);
+        var source = new byte[sourceLength];
+        var encoded = new byte[targetLength];
+        var decoded = new byte[sourceLength];
+
+        Lorem.Fill(source, 0, source.Length);
+        Fill(encoded, 0xCD);
+        Fill(decoded, 0xCD);
+
+        // Encode a full file.
+        var encodedLength = LZ4Codec.Encode(
+            source.AsSpan(),
+            encoded.AsSpan());
+
+        // Verify data after encodedLength was not overwritten.
+        Check(encoded, encodedLength, encoded.Length - encodedLength, 0xCD);
+
+        // Partially decode the file.
+        var decodedLength = LZ4Codec.DecodePartial(
+            encoded.AsSpan(0, encodedLength),
+            decoded.AsSpan(0, numToDecompress));
+
+        // Verify expected length was decompressed.
+        Assert.Equal(numToDecompress, decodedLength);
+        Check(decoded, 0, decodedLength, source); // Verify correct data was decoded.
+        Check(decoded, decodedLength, sourceLength - decodedLength, 0xCD); // Verify remaining padding is correct.
+    }
+
+    private static void Fill(byte[] buffer, byte value)
+    {
+        for (var i = 0; i < buffer.Length; i++)
+            buffer[i] = value;
+    }
+
+    private void Check(byte[] buffer, int offset, int length, byte value)
+    {
+        for (var i = offset; i < offset + length; i++)
+            Assert.True(buffer[i] == value, $"Value overriden @ {i}");
+    }
+
+    private void Check(byte[] buffer, int offset, int length, byte[] source)
+    {
+        for (var i = offset; i < offset + length; i++)
+            Assert.True(buffer[i] == source[i], $"Value different @ {i}");
+    }
+}

--- a/src/K4os.Compression.LZ4.Test/PartialDecompressionTests.cs
+++ b/src/K4os.Compression.LZ4.Test/PartialDecompressionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.CompilerServices;
 using TestHelpers;
 using Xunit;
 
@@ -45,21 +46,19 @@ public class PartialDecompressionTests
         Check(decoded, decodedLength, sourceLength - decodedLength, 0xCD); // Verify remaining padding is correct.
     }
 
-    private static void Fill(byte[] buffer, byte value)
-    {
-        for (var i = 0; i < buffer.Length; i++)
-            buffer[i] = value;
-    }
+    private static void Fill(byte[] buffer, byte value) => buffer.AsSpan().Fill(value); // vectorised on newer runtimes
 
     private void Check(byte[] buffer, int offset, int length, byte value)
     {
         for (var i = offset; i < offset + length; i++)
-            Assert.True(buffer[i] == value, $"Value overriden @ {i}");
+            if (buffer[i] != value)
+                Assert.Fail($"Value overriden @ {i}");
     }
 
     private void Check(byte[] buffer, int offset, int length, byte[] source)
     {
         for (var i = offset; i < offset + length; i++)
-            Assert.True(buffer[i] == source[i], $"Value different @ {i}");
+            if (buffer[i] != source[i])
+                Assert.Fail($"Value different @ {i}");
     }
 }

--- a/src/K4os.Compression.LZ4.Test/SpanTests.cs
+++ b/src/K4os.Compression.LZ4.Test/SpanTests.cs
@@ -82,23 +82,21 @@ namespace K4os.Compression.LZ4.Test
 			Check(decoded, offset + decodedLength, offset, 0xCD);
 			Check(decoded, offset, decodedLength, source);
 		}
-
-		private static void Fill(byte[] buffer, byte value)
-		{
-			for (var i = 0; i < buffer.Length; i++)
-				buffer[i] = value;
-		}
+		
+		private static void Fill(byte[] buffer, byte value) => buffer.AsSpan().Fill(value); // vectorised on newer runtimes
 
 		private void Check(byte[] buffer, int offset, int length, byte value)
 		{
 			for (var i = offset; i < offset + length; i++)
-				Assert.True(buffer[i] == value, $"Value overriden @ {i}");
+				if (buffer[i] != value)
+					Assert.Fail($"Value overriden @ {i}");
 		}
 
 		private void Check(byte[] buffer, int offset, int length, byte[] source)
 		{
 			for (var i = offset; i < offset + length; i++)
-				Assert.True(buffer[i] == source[i], $"Value different @ {i}");
+				if (buffer[i] != source[i])
+					Assert.Fail($"Value different @ {i}");
 		}
 	}
 }

--- a/src/K4os.Compression.LZ4/Engine/LLxx.cs
+++ b/src/K4os.Compression.LZ4/Engine/LLxx.cs
@@ -30,6 +30,19 @@ namespace K4os.Compression.LZ4.Engine
 					source, target, sourceLength, targetLength),
 				_ => throw AlgorithmNotImplemented(nameof(LZ4_decompress_safe))
 			};
+		
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public static int LZ4_decompress_safe_partial(
+			byte* source, byte* target, int sourceLength, int targetLength) =>
+			// Note from original LZ4 docs (since K4os.Compression.LZ4 is a source faithful port)
+			// this function effectively stops decoding on reaching targetOutputSize, so dstCapacity is kind of redundant.
+			LL.Algorithm switch {
+				Algorithm.X64 => LL64.LZ4_decompress_safe_partial(
+					source, target, sourceLength, targetLength, targetLength),
+				Algorithm.X32 => LL32.LZ4_decompress_safe_partial(
+					source, target, sourceLength, targetLength, targetLength),
+				_ => throw AlgorithmNotImplemented(nameof(LZ4_decompress_safe_partial))
+			};
 
 		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static int LZ4_decompress_safe_usingDict(

--- a/src/K4os.Compression.LZ4/Engine/LLxx.cs
+++ b/src/K4os.Compression.LZ4/Engine/LLxx.cs
@@ -40,7 +40,7 @@ namespace K4os.Compression.LZ4.Engine
 					source, target, sourceLength, targetLength, dictionary, dictionaryLength),
 				Algorithm.X32 => LL32.LZ4_decompress_safe_usingDict(
 					source, target, sourceLength, targetLength, dictionary, dictionaryLength),
-				_ => throw AlgorithmNotImplemented(nameof(LZ4_decompress_safe))
+				_ => throw AlgorithmNotImplemented(nameof(LZ4_decompress_safe_usingDict))
 			};
 
 		[MethodImpl(MethodImplOptions.NoInlining)]

--- a/src/K4os.Compression.LZ4/LZ4Codec.cs
+++ b/src/K4os.Compression.LZ4/LZ4Codec.cs
@@ -112,6 +112,25 @@ public static class LZ4Codec
 			
 		return decoded <= 0 ? -1 : decoded;
 	}
+	
+	/// <summary>Decompresses data from given buffer, stopping at <paramref name="targetLength"/>.</summary>
+	/// <param name="source">Input buffer.</param>
+	/// <param name="sourceLength">Input buffer length.</param>
+	/// <param name="target">Output buffer.</param>
+	/// <param name="targetLength">Output buffer length. Decoding stops at this amount.</param>
+	/// <returns>Number of bytes written, or negative value if output buffer is too small.</returns>
+	public static unsafe int DecodePartial(
+		byte* source, int sourceLength,
+		byte* target, int targetLength)
+	{
+		if (sourceLength <= 0)
+			return 0;
+
+		var decoded = LLxx.LZ4_decompress_safe_partial(
+			source, target, sourceLength, targetLength);
+			
+		return decoded <= 0 ? -1 : decoded;
+	}
 
 	/// <summary>Decompresses data from given buffer.</summary>
 	/// <param name="source">Input buffer.</param>
@@ -136,6 +155,22 @@ public static class LZ4Codec
 		return decoded <= 0 ? -1 : decoded;
 	}
 
+	/// <summary>Decompresses data from given buffer, stopping at <paramref name="target"/> buffer length.</summary>
+	/// <param name="source">Input buffer.</param>
+	/// <param name="target">Output buffer. Decoding stops at end of buffer.</param>
+	/// <returns>Number of bytes written, or negative value if output buffer is too small.</returns>
+	public static unsafe int DecodePartial(
+		ReadOnlySpan<byte> source, Span<byte> target)
+	{
+		var sourceLength = source.Length;
+		if (sourceLength <= 0)
+			return 0;
+
+		fixed (byte* sourceP = source)
+		fixed (byte* targetP = target)
+			return DecodePartial(sourceP, sourceLength, targetP, target.Length);
+	}
+	
 	/// <summary>Decompresses data from given buffer.</summary>
 	/// <param name="source">Input buffer.</param>
 	/// <param name="target">Output buffer.</param>

--- a/src/K4os.Compression.LZ4/LZ4Codec.cs
+++ b/src/K4os.Compression.LZ4/LZ4Codec.cs
@@ -119,7 +119,7 @@ public static class LZ4Codec
 	/// <param name="target">Output buffer.</param>
 	/// <param name="targetLength">Output buffer length. Decoding stops at this amount.</param>
 	/// <returns>Number of bytes written, or negative value if output buffer is too small.</returns>
-	public static unsafe int DecodePartial(
+	public static unsafe int PartialDecode(
 		byte* source, int sourceLength,
 		byte* target, int targetLength)
 	{
@@ -159,7 +159,7 @@ public static class LZ4Codec
 	/// <param name="source">Input buffer.</param>
 	/// <param name="target">Output buffer. Decoding stops at end of buffer.</param>
 	/// <returns>Number of bytes written, or negative value if output buffer is too small.</returns>
-	public static unsafe int DecodePartial(
+	public static unsafe int PartialDecode(
 		ReadOnlySpan<byte> source, Span<byte> target)
 	{
 		var sourceLength = source.Length;
@@ -168,7 +168,7 @@ public static class LZ4Codec
 
 		fixed (byte* sourceP = source)
 		fixed (byte* targetP = target)
-			return DecodePartial(sourceP, sourceLength, targetP, target.Length);
+			return PartialDecode(sourceP, sourceLength, targetP, target.Length);
 	}
 	
 	/// <summary>Decompresses data from given buffer.</summary>


### PR DESCRIPTION
# About

This pull request introduces public APIs to the LZ4Codec that introduce partial decompression support. Namely, it exposes the original LZ4's `LZ4_decompress_safe_partial` to the world. 

The ability to perform partial decompression can be pretty useful in the presence of SOLID blocks; it's not currently here, but the ported code supports it; so I figure it'd be handy to expose it.

## Added Public APIs

### LZ4Codec

```csharp
/// <summary>Decompresses data from the given buffer, stopping at <paramref name="targetLength"/>.</summary>
/// <param name="source">Input buffer.</param>
/// <param name="sourceLength">Input buffer length.</param>
/// <param name="target">Output buffer.</param>
/// <param name="targetLength">Output buffer length. Decoding stops at this amount.</param>
/// <returns>Number of bytes written, or a negative value if the output buffer is too small.</returns>
public static unsafe int DecodePartial(byte* source, int sourceLength, byte* target, int targetLength);

/// <summary>Decompresses data from the given buffer, stopping at the <paramref name="target"/> buffer length.</summary>
/// <param name="source">Input buffer.</param>
/// <param name="target">Output buffer. Decoding stops at the end of the buffer.</param>
/// <returns>Number of bytes written, or a negative value if the output buffer is too small.</returns>
public static unsafe int DecodePartial(ReadOnlySpan<byte> source, Span<byte> target);
```

I named these `DecodePartial` because the default is `Decode`, I wanted to keep the pattern from the original LZ4 library around.

## Tests

Tests for partial decoding were added as `PartialDecompressionTests.cs`.  
They cover a variety of test cases, including:

- Decompression of full file (full decompression but with partial method call).
- Partial decompression with prime numbers.

## Miscellaneous

I made a minor fix for an incorrect error message in call to `LZ4_decompress_safe_usingDict`, when the function for the given target was not implemented.