### PR TITLE
Use license expression for NuGet packages

### DIFF
--- a/PublicAssembly.props
+++ b/PublicAssembly.props
@@ -15,7 +15,7 @@
     <PackageId>$(AssemblyName)</PackageId>
     <RepositoryUrl>https://github.com/$(RepositoryOwner)/$(RepositoryName)</RepositoryUrl>
     <PackageProjectUrl>$(RepositoryUrl)</PackageProjectUrl>
-    <PackageLicenseUrl>$(RepositoryUrl)/blob/master/LICENSE?raw=true</PackageLicenseUrl>
+	<PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl Condition=" Exists('$(RepositoryRoot)/doc/icon.png') ">$(RepositoryUrl)/blob/master/doc/icon.png?raw=true</PackageIconUrl>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">


### PR DESCRIPTION
Use `<license type="expression">MIT</license>` for NuGet packages, instead of the deprecated `licenseUrl`, see https://learn.microsoft.com/en-us/nuget/reference/nuspec#licenseurl